### PR TITLE
Fixed some coding standard problems.

### DIFF
--- a/fflch.theme
+++ b/fflch.theme
@@ -8,11 +8,12 @@ use Drupal\file\Plugin\Core\Entity\FileInterface;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Path\AliasManager;
 use Drupal\file\Entity\File;
+use Drupal\block\Entity\Block;
 
 
 define('THEME_PATH_FFLCH', base_path() . drupal_get_path('theme', 'fflch'));
 
-function fflch_preprocess_page(&$vars) {
+function fflch_preprocess_page(array &$vars) : void {
 
   // Load the site name out of configuration.
   $config = \Drupal::config('system.site');
@@ -80,7 +81,7 @@ function fflch_preprocess_page(&$vars) {
     for ($i = 1; $i <= theme_get_setting('slideshow_count', 'fflch'); $i++) {
       $fid = theme_get_setting("slide_image_{$i}", "fflch");
       if (!empty($fid)) {
-        $file = \Drupal\file\Entity\File::load($fid[0]);
+        $file = File::load($fid[0]);
         $uri = $file->getFileUri();
         $image_path = file_create_url($uri);
       }
@@ -98,7 +99,7 @@ function fflch_preprocess_page(&$vars) {
 
 }
 
-function fflch_form_system_theme_settings_alter(&$form, FormStateInterface $form_state) {
+function fflch_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) : void {
 
   $form['fflch_settings'] = array(
     '#type' => 'details',
@@ -195,7 +196,7 @@ function fflch_form_system_theme_settings_alter(&$form, FormStateInterface $form
 
 }
 
-function fflch_settings_form_submit(&$form, FormStateInterface $form_state) {
+function fflch_settings_form_submit(array &$form, FormStateInterface $form_state) : void {
   $account = \Drupal::currentUser();
   $values = $form_state->getValues();
   for ($i = 0; $i <= theme_get_setting('slideshow_count', 'fflch'); $i++) {
@@ -217,7 +218,7 @@ function fflch_settings_form_submit(&$form, FormStateInterface $form_state) {
  * You can add template suggestions. Because menus don't know their region,
  * you first have to add a helper variable in block preprocessing:
  **/
-function fflch_preprocess_block(array &$variables) {
+function fflch_preprocess_block(array &$variables) : void {
   if (!empty($variables['elements']['#id'])) {
     $variables['content']['#attributes']['data-block-id'] = $variables['elements']['#id'];
   }
@@ -226,13 +227,13 @@ function fflch_preprocess_block(array &$variables) {
 /**
  * https://drupal.stackexchange.com/questions/250502/render-a-menu-differently-based-on-region
  * After that you can alter the menu template suggestions
- * Now you can use twig templates like menu__REGIONNAME.html.twig 
+ * Now you can use twig templates like menu__REGIONNAME.html.twig
  * for all menus in a given region.
  **/
-function fflch_theme_suggestions_menu_alter(array &$suggestions, array $variables) {
+function fflch_theme_suggestions_menu_alter(array &$suggestions, array $variables) : void {
   if (isset($variables['attributes']['data-block-id'])) {
-    $block = \Drupal\block\Entity\Block::load($variables['attributes']['data-block-id']);
-    if ($block) {
+    $block = Block::load($variables['attributes']['data-block-id']);
+    if ($block != NULL) {
       array_unshift($suggestions, 'menu__' . str_replace('-', '_', $block->getRegion()));
     }
   }


### PR DESCRIPTION
All problems:

Line   themes/custom/fflch-theme/fflch.theme
 ------ -------------------------------------------------------------------------------------------------------------
  13     Call to deprecated function drupal_get_path():
         in drupal:9.3.0 and is removed from drupal:10.0.0. Use
           \Drupal\Core\Extension\ExtensionPathResolver::getPath() instead.
  15     Function fflch_preprocess_page() has no return type specified.
  15     Function fflch_preprocess_page() has parameter $vars with no type specified.
  23     Construct empty() is not allowed. Use more strict comparison.
  23     Construct empty() is not allowed. Use more strict comparison.
  29     Construct empty() is not allowed. Use more strict comparison.
  29     Construct empty() is not allowed. Use more strict comparison.
  36     Construct empty() is not allowed. Use more strict comparison.
  36     Construct empty() is not allowed. Use more strict comparison.
  36     Construct empty() is not allowed. Use more strict comparison.
  43     Construct empty() is not allowed. Use more strict comparison.
  43     Construct empty() is not allowed. Use more strict comparison.
  49     Construct empty() is not allowed. Use more strict comparison.
  54     Construct empty() is not allowed. Use more strict comparison.
  59     Construct empty() is not allowed. Use more strict comparison.
  82     Construct empty() is not allowed. Use more strict comparison.
  84     Cannot call method getFileUri() on Drupal\file\Entity\File|null.
  85     Call to deprecated function file_create_url():
         in drupal:9.3.0 and is removed from drupal:10.0.0.
           Use the appropriate method on \Drupal\Core\File\FileUrlGeneratorInterface
           instead.
  91     Cannot call method getFilename() on Drupal\file\Entity\File|null.
  91     Construct empty() is not allowed. Use more strict comparison.
  91     Variable $file might not be defined.
  101    Function fflch_form_system_theme_settings_alter() has no return type specified.
  101    Function fflch_form_system_theme_settings_alter() has parameter $form with no type specified.
  191    Call to deprecated function drupal_get_path():
         in drupal:9.3.0 and is removed from drupal:10.0.0. Use
           \Drupal\Core\Extension\ExtensionPathResolver::getPath() instead.
  198    Function fflch_settings_form_submit() has no return type specified.
  198    Function fflch_settings_form_submit() has parameter $form with no type specified.
  202    Construct empty() is not allowed. Use more strict comparison.
  204    Only booleans are allowed in an if condition, Drupal\file\Entity\File|null given.
  209    Parameter #4 $id of method Drupal\file\FileUsage\DatabaseFileUsageBackend::add() expects string, int given.
  220    Function fflch_preprocess_block() has no return type specified.
  221    Construct empty() is not allowed. Use more strict comparison.
  232    Function fflch_theme_suggestions_menu_alter() has no return type specified.
  235    Only booleans are allowed in an if condition, Drupal\block\Entity\Block|null given.